### PR TITLE
changes the solr field name mapping in vue.js for sources

### DIFF
--- a/voyages/sitemedia/scripts/vue/variables/source.js
+++ b/voyages/sitemedia/scripts/vue/variables/source.js
@@ -1,5 +1,5 @@
 var_sources_plaintext = new TextVariable({
-    varName: "sources_plaintext",
+    varName: "sources_plaintext_search",
     label: gettext("Source of data"),
     description: "",
   },{


### PR DESCRIPTION
the search query for sources was using the "var_sources_plaintext" field, on which contains query fails for a couple of cases as it is a CharField. Its changed now to "var_sources_plaintext_search" field which is a NGramField that supports the contains  clause completely.