### PR TITLE
adding the translation and language cookie

### DIFF
--- a/voyages/apps/common/views.py
+++ b/voyages/apps/common/views.py
@@ -272,4 +272,9 @@ def set_language(request, lang_code):
     request.method = 'POST'
     request.POST = {'language': lang_code}
     django.views.i18n.set_language(request)
-    return django.http.HttpResponse(lang_code, content_type="text/plain")
+
+    django.utils.translation.activate(lang_code);
+    response = django.http.HttpResponse(lang_code, content_type="text/plain");
+    response.set_cookie(settings.LANGUAGE_COOKIE_NAME, lang_code);
+
+    return response;


### PR DESCRIPTION
The django language internationalization wasn't getting activated after setting the i18n language, causing some window components not being translated after the change. Activating the translation activation and setting the cookie works as expected.