### PR TITLE
changing the number input fields find logic

### DIFF
--- a/voyages/apps/contribute/templates/contribute/interim.html
+++ b/voyages/apps/contribute/templates/contribute/interim.html
@@ -2530,7 +2530,7 @@
             for (var i = 0; i < nkeys.length; ++i)
             {
                 var k = nkeys[i];
-                if (form.children('#' + k).length == 0) {
+                if (form.find('#' + k).length == 0) {
                     var num_field = $('<input class="' + APPENDED_FIELD_CLASS + '" type="hidden" id="' + k + '" name="' + k + '" />');
                     num_field.val(numbers[k]);
                     form.append(num_field);


### PR DESCRIPTION
On the "Edit Existing Voyage" page's review option for the "Slave(numbers)" fields, the changes weren't being reflected in the  verify page. 
This was happening because in the form, the JS code was re-appending all the number fields in the end of the form, overriding the changes in the input box. This was because the empty fields(hidden) were being appended after searching using the form.children("#id") selector. This wasn't giving the already present fields as they are not immediate nodes of the form (enclosed in the <div> tags), so, after replacing the selector with form.find("#id"), the duplicate fields weren't being added to the form.