### PR TITLE
specifying fl for download and enabling all downloads

### DIFF
--- a/voyages/apps/voyage/search_views.py
+++ b/voyages/apps/voyage/search_views.py
@@ -497,31 +497,29 @@ def ajax_download(request):
     data = json.loads(request.POST['data'])
     search = data['searchData']
     lang = request.LANGUAGE_CODE
-    results = perform_search(search, lang)
     columns = data['cols']
     excel_mode = data.get('excel_mode', True)
+
     if len(columns) == 0:
-        # Get all columns.
-        lang_version = 'lang_' + lang
-        columns = [col for col in results[0].get_stored_fields().keys() if 'lang' not in col or lang_version in col]
-        # Remove columns which have a name matching a prefix of another column.
-        copy = list(columns)
-        columns = [col for col in copy if len([x for x in copy if len(x) > len(col) and col in x]) == 0]
+        columns = [col if 'lang' not in col or 'lang_' in col else col + '_' + lang
+                   for col in download_header_map.keys()]
     else:
         columns = [col if 'lang' not in col or 'lang_' in col else col + '_' + lang for col in columns]
+
+    results = perform_search(search, lang)
+    data = get_values_from_haystack_results(results, columns)
+    rows = [[x.get(field_name) for field_name in columns] for x in data]
+
     if excel_mode:
-        return download_xls(
-            [[(_(get_download_header(col)), 1) for col in columns]],
-            [[item[col] for col in columns] for item in [x.get_stored_fields() for x in results]])
+        return download_xls([[(_(get_download_header(col)), 1) for col in columns]], rows)
     else:
         response = HttpResponse(content_type='text/csv')
         response['Content-Disposition'] = 'attachment; filename="data.csv"'
         writer = unicodecsv.DictWriter(response, fieldnames=columns)
         #writer.writeheader()
         writer.writerow({col: _(get_download_header(col)) for col in columns})
-        for x in results:
-            item = x.get_stored_fields()
-            writer.writerow({col: item[col] for col in columns})
+        for x in rows:
+            writer.writerow({columns[colNum]: x[colNum] for colNum in range(len(columns))})
         return response
 
 _options_model = {

--- a/voyages/sitemedia/scripts/vue/includes/helpers.js
+++ b/voyages/sitemedia/scripts/vue/includes/helpers.js
@@ -1138,10 +1138,10 @@ function refreshUi(filter, filterData, currentTab, tabData, options) {
       return function() {
         // TODO (20190710): Remove the next few lines when proper column
         // headers and a canonical order are defined for the download.
-        if (!isVisibleColumns) {
-          alert("The download option with all columns is not available yet.");
-          return;
-        }
+        // if (!isVisibleColumns) {
+        //   alert("The download option with all columns is not available yet.");
+        //   return;
+        // }
         // decides if it's returning visible columns or all columns
         var visibleColumns = isVisibleColumns
           ? mainDatatable.columns().visible().context[0].aoColumns.map(function(variable){if (variable.bVisible) return variable.data }).filter(Boolean)


### PR DESCRIPTION
The download was timing out because of the size and the django internal pagination for fetching the resultset.
After passing the fields for the visible columns download features and fetching the complete resultset, the download is not timing out.
For the all fields' download, after specifying the fields that are in the "download_header_map" which has 66 as oppsed to the 118 in solr, the query is returning results without timeout.  So, I have enabled that feature on the UI.