### PR TITLE
applied blog patches from domingos, sept 28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tmp/
 google_auth.json
 documents/audio/**
 documents/blog/**
+documents/_versions/**

--- a/voyages/apps/blog/templates/blog/index.html
+++ b/voyages/apps/blog/templates/blog/index.html
@@ -23,7 +23,15 @@
 
 
 <div class="nav-header">
-	<div>{% block title %} {% trans 'Echoes: The SlaveVoyages Blog' %} {% endblock title %}</div>
+	<div>
+    {% block title %}    
+      {% if title_override %}
+        {% trans title_override %}
+      {% else %}
+        {% trans 'Echoes: The SlaveVoyages Blog' %}
+      {% endif %}
+    {% endblock title %}
+  </div>
 	<div class="navbar-subtitle flex">
 		
 	</div>

--- a/voyages/apps/blog/views.py
+++ b/voyages/apps/blog/views.py
@@ -9,7 +9,12 @@ register = template.Library()
 class PostList(generic.ListView):    
     template_name = 'blog/index.html'
     paginate_by = 10
-
+    
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['title_override'] = self.kwargs.get('title_override')
+        return context
+	
     def get_queryset(self):
         lang_code = self.request.LANGUAGE_CODE or "en"
 

--- a/voyages/apps/common/views.py
+++ b/voyages/apps/common/views.py
@@ -189,8 +189,9 @@ def get_flat_page_tree(prefix, language=None):
         # order should be numeric
         order = None
         try:
-            order = float(order_str)
+            order = float(order_str) + 1
         except Exception:
+            print(f"Bad order in flatpage URL {page.url}")
             pass
         d = structure
         for item in path:

--- a/voyages/apps/resources/urls.py
+++ b/voyages/apps/resources/urls.py
@@ -5,6 +5,7 @@ from django.views.generic import TemplateView
 
 import voyages.apps.resources.views
 import voyages.apps.static_content.views
+from voyages.apps.blog.views import PostList
 
 urlpatterns = [
     url(r'^$',
@@ -17,8 +18,8 @@ urlpatterns = [
     url(r'^downloads',
         TemplateView.as_view(template_name='resources/downloads.html'),
         name='downloads'),
-    url(r'^lessons',
-        TemplateView.as_view(template_name='resources/lessons.html'),
+    url(r'^lessons', PostList.as_view(),
+        kwargs={"tag": "lesson-plan", "title_override": "Lesson Plans"},
         name='lessons'),
     url(r'^links',
         TemplateView.as_view(template_name='resources/links.html'),


### PR DESCRIPTION
1. corrects flat page ordering problem
2. we're not seeing the caching issue locally or on staging, so that's ignored for now
3. replaces lesson plan flat pages with blog posts tagged as "Lesson Plan" (see apps/resources/urls)