### PR TITLE
Enslaver contribution with newly proposed UX

### DIFF
--- a/voyages/apps/contribute/templates/contribute/editor_main.html
+++ b/voyages/apps/contribute/templates/contribute/editor_main.html
@@ -37,6 +37,7 @@
   <ul class="nav nav-pills nav-fill" role="tablist">
     <li class="nav-item" role="presentation"><a class="nav-link " id="tab_pending" href="#pending" aria-controls="voyages" role="tab" data-toggle="tab">{% trans "Voyages" %}</a></li>
     <li class="nav-item" role="presentation"><a class="nav-link active" id="tab_requests" href="#requests" aria-controls="requests" role="tab" data-toggle="tab">{% trans "Requests" %}</a></li>
+    <li class="nav-item" role="presentation"><a class="nav-link" id="tab_enslavers_contrib" href="#enslavers_contrib" aria-controls="requests" role="tab" data-toggle="tab">{% trans "Enslavers" %}</a></li>
     <li class="nav-item" role="presentation"><a class="nav-link " href="#users" aria-controls="users" role="tab" data-toggle="tab">{% trans "Users" %}</a></li>
     <li class="nav-item" role="presentation"><a class="nav-link " href="#sources" aria-controls="sources" role="tab" data-toggle="tab">{% trans "Source Codes" %}</a></li>
     <li class="nav-item" role="presentation"><a class="nav-link " href="#publish" aria-controls="publish" role="tab" data-toggle="tab">{% trans "Publish New DB Version" %}</a></li>
@@ -94,6 +95,20 @@
             </tbody>
         </table>
       </div>
+    </div>
+    <div role="tabpanel" class="tab-pane" id="enslavers_contrib">
+        <table id="enslavers_table" class="table table-striped table-bordered" cellspacing="0" width="100%">
+            <thead>
+            <tr>
+                <th>{% trans "Type" %}</th>
+                <th>{% trans "Enslaver" %}</th>
+                <th>{% trans "Contributor" %}</th>
+                <th>{% trans "Date" %}</th>
+            </tr>
+            </thead>
+            <tbody>
+            </tbody>
+        </table>
     </div>
     <div role="tabpanel" class="tab-pane" id="users">
       <div class="page-title-1">
@@ -263,11 +278,56 @@
         });
     }
 
+    const icons = {
+        "new": "file-alt",
+        "merge": "code-fork",
+        "split": "random"
+    };
+
+    async function loadEnslaversContribList() {
+        // This is a later development that uses more recent js features.
+        const res = await fetch("/contribute/enslaver_contribution_list", {
+            method: 'POST',
+            data: "{}"
+        });
+        const data = await res.json();
+        if (!$('#enslavers_table').data('hasInitialized')) {
+            $("#enslavers_table").DataTable({
+                dom: '<"toolbar">',
+                data: data.results,
+                columns: [{
+                        data: function(row, type, set) {
+                            return {
+                                icon: icons[row.type] || row.type,
+                                pk: row.pk
+                            };
+                        },
+                        render: function(data, type) {
+                            if (type === 'display') {
+                                return `<a href="/contribute/enslaver_contribution_review/${data.pk}"><i class="fa fa-${data.icon}"></i></a>`;
+                            }
+                            return data;
+                        }
+                    },
+                    { data: 'enslaver_identity' },
+                    { data: 'contributor_name' },
+                    { data: 'created' }
+                ],
+                paging: false,
+                info: false,
+                bFilter: false
+            });
+            $('#enslavers_table').data('hasInitialized', true);
+        }
+    }
+
     var loadTabData = function(href) {
         if (href == '#requests') {
             loadRequestsList();
         } else if (href == '#pending') {
             loadPendingList();
+        } else if (href == '#enslavers_contrib') {
+            loadEnslaversContribList();
         }
     };
     loadTabData('#' + $('.tab-pane.active').attr('id'));

--- a/voyages/apps/contribute/templates/contribute/editor_main.html
+++ b/voyages/apps/contribute/templates/contribute/editor_main.html
@@ -150,6 +150,7 @@
 <script type="text/javascript" src="{{ STATIC_URL }}scripts/contribute/common.js"></script>
 <script type="text/javascript" src="{{ STATIC_URL }}scripts/contribute/editorial.js"></script>
 <script type="text/javascript" src="{{ STATIC_URL }}scripts/legacy/utils.js"></script>
+<script type="text/javascript" src="{{ STATIC_URL }}scripts/vue/enslavers/icons.js"></script>
 <script type="text/javascript">
     var reviewClasses = ['alert-info', 'alert-success', 'alert-danger'];
     var contribTypes = {'edit': '<span class="fa fa-edit">',
@@ -277,13 +278,6 @@
             }
         });
     }
-
-    const icons = {
-        "new": "file-alt",
-        "merge": "code-fork",
-        "split": "random"
-    };
-
     async function loadEnslaversContribList() {
         // This is a later development that uses more recent js features.
         const res = await fetch("/contribute/enslaver_contribution_list", {
@@ -298,7 +292,7 @@
                 columns: [{
                         data: function(row, type, set) {
                             return {
-                                icon: icons[row.type] || row.type,
+                                icon: get_enslaver_contrib_icon(row.type),
                                 pk: row.pk
                             };
                         },

--- a/voyages/apps/past/templates/past-contribute/_enslaver_contrib_aliases.html
+++ b/voyages/apps/past/templates/past-contribute/_enslaver_contrib_aliases.html
@@ -77,7 +77,7 @@
                     {% trans "No linked voyage" %}
                 </option>
                 <option v-for="voyage in selAlias().voyages" class="list-group-item" v-bind:value="'V' + [[ voyage.pk ]]">
-                    {% trans "Voyage" %} [[ voyage.pk ]] - [[ voyage.ship_name ]], [[ voyage.arrival.replaceAll(',', '') ]]
+                    {% trans "Voyage" %} [[ voyage.pk ]] - [[ voyage.ship_name ]], [[ voyage.arrival.replaceAll(',', '') ]] [[ voyage.role ? `(${enslaverRoles[voyage.role]})` : "" ]]
                 </option>
                 <option disabled v-if="selAlias().relations?.length === 0">
                     {% trans "No enslavement relations" %}
@@ -123,12 +123,17 @@
                 </button>
             </div>
             <div class="modal-body">
+                <label for="linkVoyageIdField">{% trans "Voyage ID" %}:</label>
                 <input class="form-control" name="linkVoyageIdField" type="number" v-model="linkVoyageInput" autofocus />
-                <!-- TODO: selection box with roles. -->
-                <input class="form-control" name="linkVoyageRole" type="number" v-model="linkVoyageRole" autofocus />
+                <label for="linkVoyageRoleField">{% trans "Enslaver Role" %}:</label>
+                <select v-model="linkVoyageRole" name="linkVoyageRoleField" class="form-control">
+                    <option v-for="[ key, val ] in Object.entries(enslaverRoles)" v-bind:value="key">
+                        [[val]]
+                    </option>
+                </select>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary" v-on:click="linkVoyage">{% trans "Link" %}</button>
+                <button type="button" class="btn btn-primary" v-bind:class="{ disabled: !linkVoyageInput || !linkVoyageRole }" v-on:click="linkVoyage">{% trans "Link" %}</button>
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">{% trans "Close" %}</button>
             </div>
         </div>

--- a/voyages/apps/past/templates/past-contribute/_enslaver_contrib_personal.html
+++ b/voyages/apps/past/templates/past-contribute/_enslaver_contrib_personal.html
@@ -223,7 +223,7 @@
         <div 
             v-for="identity in interim.identities" 
             v-bind:class="[[ isThreeColumnLayout ? 'col-md-3' : 'col-md-9' ]]">
-            <input class="form-control" type="number" v-model="identity.personal_data.notes"
+            <input class="form-control" type="text" v-model="identity.personal_data.notes"
                 v-bind:disabled="interim.type === 'merge' && identity.id !== 'merged'">
         </div>
     </div>

--- a/voyages/apps/past/templates/past/enslavers.html
+++ b/voyages/apps/past/templates/past/enslavers.html
@@ -155,6 +155,7 @@
 <script src="{{ STATIC_URL }}scripts/vue/components/v-dropdown.js"></script>
 <!-- vue components -->
 
+<script src="{{ STATIC_URL }}scripts/vue/enslavers/icons.js" type="text/javascript"></script>
 <script src="{{ STATIC_URL }}scripts/vue/enslavers/search.js" type="text/javascript"></script>
 <script src="{{ STATIC_URL }}scripts/vue/enslavers/app.js" type="text/javascript"></script>
 

--- a/voyages/apps/past/templates/past/enslavers_contribute.html
+++ b/voyages/apps/past/templates/past/enslavers_contribute.html
@@ -51,16 +51,27 @@
                 <li>                            
                     <button v-on:click="goBack"><i class="fa fa-arrow-left"></i></button>
                 </li>
+                {% if mode != 'delete' %}
                 <li class="nav-item">
-                    <a class="nav-link active" href="#aliases" data-toggle="tab" data-target="#aliases">{% trans 'Aliases and Voyages' %}</a>
+                    <a class="nav-link active" href="#aliases" data-
+toggle="tab" data-target="#aliases">{% trans 'Aliases and Voyages' %}</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="#personal" data-toggle="tab" data-target="#personal">{% trans 'Personal information' %}</a>
                 </li>
+                {% endif %}
                 <li class="nav-item">
-                    <a class="nav-link" href="#notes" data-toggle="tab" data-target="#notes">
+                    <a 
+                        {% if mode != 'delete' %}
+                        class="nav-link"
+                        {% else %}
+                        class="nav-link active"
+                        {% endif %}
+                        href="#notes" data-toggle="tab" data-target="#notes">
                         {% if editorialMode %}
                             {% trans 'Notes from contributor' %}
+                        {% elif mode == 'delete' %}
+                            {% trans 'Why should this record be deleted?' %}
                         {% else %}
                             {% trans 'Notes to editor' %}
                         {% endif %}
@@ -73,14 +84,25 @@
             
             <!-- TabContainers -->
             <div id="tabsJustifiedContent" class="tab-content">
+                {% if mode != 'delete' %}
                 <div id="aliases" class="tab-pane fade active show">
                     {% include "past-contribute/_enslaver_contrib_aliases.html" %}
                 </div>
                 <div id="personal" class="tab-pane fade">
                     {% include "past-contribute/_enslaver_contrib_personal.html" %}
                 </div>
-                <div id="notes" class="tab-pane fade">
+                {% endif %}
+                <div
+                    {% if mode != 'delete' %}
+                        class="tab-pane fade"
+                    {% else %}
+                        class="tab-pane active show"
+                    {% endif %}
+                        id="notes">
                     <textarea name="notes" class="form-control enslaver_contrib_fullspan_control" v-model="interim.notes"></textarea>
+                    {% if mode == 'delete' %}
+                        
+                    {% endif %}
                 </div>
                 <div id="review" class="tab-pane fade">
                     <div class="panel panel-danger" v-if="validation.length > 0">

--- a/voyages/apps/past/templates/past/enslavers_contribute.html
+++ b/voyages/apps/past/templates/past/enslavers_contribute.html
@@ -215,7 +215,7 @@
             delimiters: ['[[', ']]'],
             data: {
                 places,
-                enslaverRoles: Object.entries(enslaverRoles),
+                enslaverRoles,
                 interim,
                 selectedAlias: null,
                 selectedIdentity: interim.type === "merge"
@@ -384,12 +384,13 @@
                 },
                 linkVoyage: async function() {
                     const alias = this.selAlias();
-                    if (alias && this.linkVoyageInput) {
+                    if (alias && this.linkVoyageInput && this.linkVoyageRole) {
                         const res = await fetch(`/contribute/voyage_summary/${this.linkVoyageInput}`);
                         const data = await res.json();
                         if (data.error || !data.pk) {
                             alert(`Error fetching voyage id ${this.linkVoyageInput}: ${data.error}.`);
                         } else {
+                            data["role"] = parseInt(this.linkVoyageRole);
                             alias.voyages.push(data);
                             this.linkVoyageInput = null;
                         }    

--- a/voyages/apps/past/urls.py
+++ b/voyages/apps/past/urls.py
@@ -4,14 +4,12 @@ from django.conf.urls import url
 from django.views.generic import TemplateView
 
 import voyages.apps.static_content.views
-from voyages.settings import is_feature_enabled
 
 urlpatterns = [
     url(r'^api/search_enslaved',
         voyages.apps.past.views.search_enslaved, name='search_enslaved'),
     url(r'^api/search_enslaver',
-        voyages.apps.past.views.search_enslaver, name='search_enslaver') \
-            if is_feature_enabled('ENSLAVERS') else None,
+        voyages.apps.past.views.search_enslaver, name='search_enslaver'),
     url(r'^api/modern-countries',
         voyages.apps.past.views.get_modern_countries,
         name='modern-countries'),
@@ -26,28 +24,25 @@ urlpatterns = [
         name='database'),
     url(r'^enslavement_relation/(?P<relation_pk>[\w\-]+)$',
         voyages.apps.past.views.get_enslavement_relation_info,
-        name='enslavement_relation') \
-            if is_feature_enabled('ENSLAVERS') else None,
+        name='enslavement_relation'),
     url(r'^enslavers_contribute/new$',
         voyages.apps.past.views.enslaver_contrib_new,
-        name='enslaver_contribute_new') \
-            if is_feature_enabled('ENSLAVERS') else None,
+        name='enslaver_contribute_new'),
+    url(r'^enslavers_contribute/delete/(?P<id>.*)',
+        voyages.apps.past.views.enslaver_contrib_delete,
+        name='enslaver_contribute_delete'),
     url(r'^enslavers_contribute/edit/(?P<id>.*)',
         voyages.apps.past.views.enslaver_contrib_edit,
-        name='enslaver_contribute_edit') \
-            if is_feature_enabled('ENSLAVERS') else None,
+        name='enslaver_contribute_edit'),
     url(r'^enslavers_contribute/split/(?P<id>.*)',
         voyages.apps.past.views.enslaver_contrib_split,
-        name='enslaver_contribute_split') \
-            if is_feature_enabled('ENSLAVERS') else None,
+        name='enslaver_contribute_split'),
     url(r'^enslavers_contribute/merge/(?P<merge_a>.*)/(?P<merge_b>.*)',
         voyages.apps.past.views.enslaver_contrib_merge,
-        name='enslaver_contribute_merge') \
-            if is_feature_enabled('ENSLAVERS') else None,
+        name='enslaver_contribute_merge'),
      url(r'^enslavers$',
         TemplateView.as_view(template_name='past/enslavers.html'),
-        name='enslavers') \
-            if is_feature_enabled('ENSLAVERS') else None,
+        name='enslavers'),
     url(r'^contribute/(?P<id>.*)',
         TemplateView.as_view(template_name='past/contribute.html'),
         name='contribute'),

--- a/voyages/apps/past/views.py
+++ b/voyages/apps/past/views.py
@@ -144,7 +144,7 @@ def get_language_groups(_):
 def get_enumeration(_, model_name):
     from django.apps import apps
     model = apps.get_model(app_label="past", model_name=model_name.replace('-', ''))
-    return JsonResponse({x.pk: x.name for x in model.objects.all()})
+    return JsonResponse({int(x.pk): x.name for x in model.objects.all()})
 
 
 def restore_enslaved_permalink(_, link_id):

--- a/voyages/apps/past/views.py
+++ b/voyages/apps/past/views.py
@@ -363,6 +363,9 @@ def _enslaver_contrib_action(request, data):
         return HttpResponseRedirect(reverse('account_login'))
     return render(request, 'past/enslavers_contribute.html', data)
 
+def enslaver_contrib_delete(request, id):
+    return _enslaver_contrib_action(request, { "mode": "delete", "id": id })
+
 def enslaver_contrib_edit(request, id):
     return _enslaver_contrib_action(request, { "mode": "edit", "id": id })
 
@@ -395,7 +398,10 @@ def enslaver_contrib_editorial_review(request, pk):
     contrib = get_object_or_404(EnslaverContribution, pk=pk)
     if contrib.status == EnslavedContributionStatus.ACCEPTED:
         raise Http404("This contribution has already been accepted")
+    # Parsing makes sure that we have valid JSON data.
+    interim = json.loads(contrib.data)
     return render(request, 'past/enslavers_contribute.html', {
+        'mode': interim['type'],
         'interim': contrib.data,
         'editorialMode': True,
         'contrib_pk': pk

--- a/voyages/sitemedia/scripts/vue/enslavers/icons.js
+++ b/voyages/sitemedia/scripts/vue/enslavers/icons.js
@@ -1,0 +1,8 @@
+const enslaver_contrib_icons = {
+    "new": "file-alt",
+    "merge": "code-fork",
+    "split": "columns",
+    "delete": "trash"
+};
+
+const get_enslaver_contrib_icon = (key) => enslaver_contrib_icons[key] || key;

--- a/voyages/sitemedia/scripts/vue/enslavers/includes/helpers.js
+++ b/voyages/sitemedia/scripts/vue/enslavers/includes/helpers.js
@@ -1056,6 +1056,8 @@ function formatRelations ( d ) {
   return relationsTable;
 }
 
+var mainDatatable = null;
+
 function refreshUi(filter, filterData, currentTab, tabData, options) {
   if (currentTab == "results") {
     var currentSearchObj = searchAll(filter, filterData);
@@ -1070,7 +1072,7 @@ function refreshUi(filter, filterData, currentTab, tabData, options) {
       className: "btn btn-info buttons-collection dropdown-toggle"
     };
 
-    var mainDatatable = $("#results_main_table").DataTable({
+    mainDatatable = $("#results_main_table").DataTable({
       ajax: {
         url: SEARCH_URL,
         type: "POST",
@@ -1088,9 +1090,10 @@ function refreshUi(filter, filterData, currentTab, tabData, options) {
             }
 
             currentSearchObj.order_by = $.map(d.order, function(item) {
-              var columnIndex = mainDatatable
+              // TODO [colReorder disabled]
+              var columnIndex = /* mainDatatable
                 ? mainDatatable.colReorder.order()[item.column]
-                : item.column;
+                :*/ item.column;
               return {
                 columnName: allColumns[columnIndex].data,
                 direction: item.dir
@@ -1123,7 +1126,10 @@ function refreshUi(filter, filterData, currentTab, tabData, options) {
 
       scrollX: true,
 
-      colReorder: true,
+      // TODO [colReorder disabled]: mainDatatable.colReorder.order() is
+      // throwing and the reason is not clear yet (maybe a bug in the library).
+      
+      //colReorder: true,
 
       order: [[4, "desc"]],
       destroy: true,
@@ -1144,6 +1150,7 @@ function refreshUi(filter, filterData, currentTab, tabData, options) {
       language: dtLanguage,
 
       buttons: [
+        enslaversContributeMenu,
         columnToggleMenu,
         //pageLength,
       ],
@@ -1157,7 +1164,8 @@ function refreshUi(filter, filterData, currentTab, tabData, options) {
       initComplete: function() {
         $('[data-toggle="tooltip"]').tooltip();
         initAudioActions();
-      },
+        updateContribState(JSON.parse(sessionStorage.getItem(contribStateStorageKey) || "{}"));
+      }
     });
 
     mainDatatable.on("column-reorder", function(e, settings, details) {

--- a/voyages/sitemedia/scripts/vue/enslavers/search.js
+++ b/voyages/sitemedia/scripts/vue/enslavers/search.js
@@ -109,16 +109,9 @@ allColumns.forEach(function(c, index) {
         formattedString = "";
         try {
           const contribState = JSON.parse(sessionStorage.getItem(contribStateStorageKey) || "{}");
-          if (contribState?.mode === 'edit' || contribState?.mode === 'split') {
-            let icon = contribState.mode;
-            if (icon === 'split') {
-              icon = 'columns';
-            }
+          if (contribState?.mode === 'edit' || contribState?.mode === 'split' || contribState?.mode === 'delete') {
+            let icon = get_enslaver_contrib_icon(contribState.mode);
             formattedString = `<a href="/past/enslavers_contribute/${contribState.mode}/${data}"><i class="fas fa-blended-color fa-${icon} btn btn-transparent"></i></a>`;
-          } else if (contribState?.mode === 'delete') {
-            // TODO: implement delete contrib.
-            formattedString = `<a href="#" onclick="alert('not implemented yet')"><i class="fas fa-blended-color fa-trash btn btn-transparent"></i></a>`;
-            // formattedString = `<a href="/past/enslavers_contribute/delete/${data}"><i class="fas fa-trash btn btn-transparent"></i></a>`;
           } else if (contribState?.mode === 'merge') {
             const isChecked = contribState.selection.includes(data);
             formattedString = `<input onchange="contribMergeChange(this)" type="checkbox" value="${data}"${isChecked ? " checked" : ""}></input>`;
@@ -176,6 +169,7 @@ const contributeColHeaders = {
 
 const updateContribState = (state) => {
   const col = mainDatatable.column("contribute:name");
+  const btn = mainDatatable.button('hide_enslaver_contrib_action:name');
   const prev = JSON.parse(sessionStorage.getItem(contribStateStorageKey) || "{}");
   if (!!state?.mode) {
     sessionStorage.setItem(contribStateStorageKey, JSON.stringify(state));
@@ -184,8 +178,10 @@ const updateContribState = (state) => {
       header = `${header} <span class="badge badge-pill badge-secondary tooltip-pointer" data-toggle="tooltip" data-placement="top" title="${gettext('There is already an enslaver selected for the merge operation')}" data-original-title=""> ${state.selection.length} </span>`;
     }
     col.header().innerHTML = header;
+    btn.enable();
   } else {
     sessionStorage.setItem(contribStateStorageKey, "{}");
+    btn.disable();
   }
   col.visible(!!state?.mode);
   if (prev?.mode !== state?.mode) {
@@ -226,6 +222,7 @@ const enslaversContributeMenu = {
     }
   }, {
     text: gettext('Hide action column'),
+    name: 'hide_enslaver_contrib_action',
     action: function() {
       updateContribState(null);
     }

--- a/voyages/sitemedia/scripts/vue/enslavers/search.js
+++ b/voyages/sitemedia/scripts/vue/enslavers/search.js
@@ -2,13 +2,14 @@ var categoryNames = [
   gettext("Name"),
   gettext("Itinerary"),
   gettext("Personal Data"),
-  gettext("Biographical Sources"),
-  gettext("Contribution"),
+  gettext("Biographical Sources")
 ];
 
 function bioSourceHeader() {
   return `${gettext("Biographical Sources")} <span class="badge badge-pill badge-secondary tooltip-pointer" data-toggle="tooltip" data-placement="top" title="${gettext("Sources for associated voyages appear in each voyage record")}"> SRC </span>`;
 }
+
+const contributeCol = { data: "id", header: "", name: "contribute", className: "text-center", isImputed: false, isContribute: true, orderable: false, visible: false };
 
 var allColumns = [
   // name
@@ -31,7 +32,7 @@ var allColumns = [
   // sources
   { data: "sources_list", category: 3, header: bioSourceHeader(), isImputed: false, visible: false, orderable: false },
 
-  { data: "id", category: 4, header: gettext("Contribute"), isImputed: false, isContribute: true, orderable: false },
+  contributeCol
   
 ];
 
@@ -42,17 +43,48 @@ var categories = $.map(categoryNames, function(name) {
   };
 });
 
-allColumns.forEach(function(c, index) {
+const contribStateStorageKey = "enslaverContributeState";
 
+const contribMergeChange = (sel) => {
+  try {
+    const contribState = JSON.parse(sessionStorage.getItem(contribStateStorageKey));
+    const { selection } = contribState;
+    const key = parseInt(sel.value);
+    if (!!sel.checked === selection.includes(key)) {
+      // Nothing changes.
+      return;
+    }
+    if (sel.checked) {
+      selection.push(key);
+      if (selection.length >= 2) {
+        // Ready to merge.
+        sessionStorage.setItem(contribStateStorageKey, "{}");
+        window.location.href = `/past/enslavers_contribute/merge/${selection[0]}/${selection[1]}`;
+        return;
+      }
+    } else {
+      selection.splice(selection.indexOf(key), 1);
+    }
+    updateContribState(contribState);
+  } catch {
+  }
+};
+
+allColumns.forEach(function(c, index) {
   var title = c.isImputed ? "<span>" + c.header + "</span> <span class='badge badge-pill badge-secondary' data-toggle='tooltip' data-placement='top' title='" + gettext("Imputed results are calculated by an algorithm.") + "'> IMP </span>" : gettext(c.header);
 
-  categories[c.category].columns.push({
-    extend: 'columnToggle',
-    text: title,
-    columns: index,
-  });
-
-  c.title = "<span class='column-header'>" + c.header + "</span>";
+  if (c.category) {
+    categories[c.category].columns.push({
+      extend: 'columnToggle',
+      text: title,
+      columns: index,
+    });
+  }
+  
+  if (c.isContribute) {
+  } else {
+    c.title = "<span class='column-header'>" + c.header + "</span>";
+  }
 
   // add render function to customize the display of imputed variables
   if (c.isImputed) {
@@ -75,10 +107,27 @@ allColumns.forEach(function(c, index) {
         // Read local storage to determine what type of contribution was
         // started in the UI.
         formattedString = "";
-        //formattedString = `<a href="/past/enslavers_contribute/edit/${data}"><i class="fas fa-edit btn btn-transparent"></i></a>`;
+        try {
+          const contribState = JSON.parse(sessionStorage.getItem(contribStateStorageKey) || "{}");
+          if (contribState?.mode === 'edit' || contribState?.mode === 'split') {
+            let icon = contribState.mode;
+            if (icon === 'split') {
+              icon = 'columns';
+            }
+            formattedString = `<a href="/past/enslavers_contribute/${contribState.mode}/${data}"><i class="fas fa-blended-color fa-${icon} btn btn-transparent"></i></a>`;
+          } else if (contribState?.mode === 'delete') {
+            // TODO: implement delete contrib.
+            formattedString = `<a href="#" onclick="alert('not implemented yet')"><i class="fas fa-blended-color fa-trash btn btn-transparent"></i></a>`;
+            // formattedString = `<a href="/past/enslavers_contribute/delete/${data}"><i class="fas fa-trash btn btn-transparent"></i></a>`;
+          } else if (contribState?.mode === 'merge') {
+            const isChecked = contribState.selection.includes(data);
+            formattedString = `<input onchange="contribMergeChange(this)" type="checkbox" value="${data}"${isChecked ? " checked" : ""}></input>`;
+          }
+        } catch {
+        }
       } else if (c.data == 'voyages_list' || c.data == 'relations_list') {
         if (data.length > 0) {
-          formattedString = '<i class="fa fa-plus-square" aria-hidden="true"></i>';
+          formattedString = '<i class="fa fa-plus-square fa-blended-color" aria-hidden="true"></i>';
         }
       } else if (c.data == 'alias_list') {
         formattedString += "<span class=\"h6 pr-2\"><span class=\"badge badge-pill badge-secondary\">"+row.principal_alias+"</span></span>";
@@ -117,6 +166,71 @@ var restoreBtn = {
 };
 
 defaultBtns.push(restoreBtn);
+
+const contributeColHeaders = {
+  "edit": gettext("Edit"),
+  "merge": gettext("Merge"),
+  "delete": gettext("Delete"),
+  "split": gettext("Split aliases"),
+}
+
+const updateContribState = (state) => {
+  const col = mainDatatable.column("contribute:name");
+  const prev = JSON.parse(sessionStorage.getItem(contribStateStorageKey) || "{}");
+  if (!!state?.mode) {
+    sessionStorage.setItem(contribStateStorageKey, JSON.stringify(state));
+    let header = contributeColHeaders[state.mode];
+    if (state.mode === 'merge' && state.selection.length > 0) {
+      header = `${header} <span class="badge badge-pill badge-secondary tooltip-pointer" data-toggle="tooltip" data-placement="top" title="${gettext('There is already an enslaver selected for the merge operation')}" data-original-title=""> ${state.selection.length} </span>`;
+    }
+    col.header().innerHTML = header;
+  } else {
+    sessionStorage.setItem(contribStateStorageKey, "{}");
+  }
+  col.visible(!!state?.mode);
+  if (prev?.mode !== state?.mode) {
+    mainDatatable.draw();
+  }
+}
+
+const enslaversContributeMenu = {
+  extend: 'collection',
+  autoClose: true,
+  text: gettext('Contribute data'),
+  titleAttr: gettext('Propose changes or additions to the Enslavers dataset'),
+  className: 'btn btn-info buttons-collection dropdown-toggle',
+  buttons: [{
+    text: gettext('New enslaver record'),
+    action: function() {
+      window.location.href = "/past/enslavers_contribute/new";
+    }
+  }, {
+    text: gettext('Edit an enslaver record'),
+    action: function() {
+      updateContribState({ mode: "edit" });
+    }
+  }, {
+    text: gettext('Merge duplicate enslaver records'),
+    action: function() {
+      updateContribState({ mode: "merge", selection: [] });
+    }
+  }, {
+    text: gettext('Delete an enslaver record'),
+    action: function() {
+      updateContribState({ mode: "delete" });
+    }
+  }, {
+    text: gettext('Unlink an alias from the enslaver'),
+    action: function() {
+      updateContribState({ mode: "split" });
+    }
+  }, {
+    text: gettext('Hide action column'),
+    action: function() {
+      updateContribState(null);
+    }
+  }]
+};
 
 var columnToggleMenu = {
   extend: 'collection',

--- a/voyages/sitemedia/scripts/vue/enslavers/search.js
+++ b/voyages/sitemedia/scripts/vue/enslavers/search.js
@@ -72,7 +72,10 @@ allColumns.forEach(function(c, index) {
       if (c.data == 'sources_list') {
         formattedString = data;
       } else if (c.isContribute) {
-        formattedString = `<a href="/past/enslavers_contribute/edit/${data}"><i class="fas fa-edit btn btn-transparent"></i></a>`;
+        // Read local storage to determine what type of contribution was
+        // started in the UI.
+        formattedString = "";
+        //formattedString = `<a href="/past/enslavers_contribute/edit/${data}"><i class="fas fa-edit btn btn-transparent"></i></a>`;
       } else if (c.data == 'voyages_list' || c.data == 'relations_list') {
         if (data.length > 0) {
           formattedString = '<i class="fa fa-plus-square" aria-hidden="true"></i>';

--- a/voyages/sitemedia/scss/past.scss
+++ b/voyages/sitemedia/scss/past.scss
@@ -347,7 +347,7 @@ input.button-save:hover {
   background-color: rgb(63, 150, 125);
 }
 
-.fa-plus-square, .fa-minus-square {
+.fa-plus-square, .fa-minus-square, .fa-blended-color {
   color: rgb(63, 150, 125);
 }
 

--- a/voyages/urls.py
+++ b/voyages/urls.py
@@ -49,8 +49,7 @@ urlpatterns = [
         name='restore_enslaved_permalink'),
     url(r'^enslaver/(?P<link_id>\w+)',
         voyages.apps.past.views.restore_enslaver_permalink,
-        name='restore_enslaver_permalink') \
-            if is_feature_enabled('ENSLAVERS') else None,
+        name='restore_enslaver_permalink'),
 
     # Include url handlers of each section
     url(r'^voyage/', include('voyages.apps.voyage.urls', namespace='voyage')),


### PR DESCRIPTION
This PR implements an integrated contribute dropdown on the Enslavers database page.

- Once the action is selected from the dropdown, every row becomes actionable
- Merge is more complicated since it requires the selection of two different rows, possibly across different *search queries* so checkboxes are displayed for each row, header is updated to indicate a selection (which might belong to a different table page or search query).
- Delete contribution now implemented using the same UI for other types, removing the tabs that do not apply.
- Editorial platform now displays all pending enslaver contributions for editorial reviews.